### PR TITLE
feat: Implement Task::new_with_id method to create task with predefined Id

### DIFF
--- a/src/job.rs
+++ b/src/job.rs
@@ -4,7 +4,7 @@ use uuid::Uuid;
 
 #[derive(Debug, PartialEq, Eq, Clone, PartialOrd, Ord, Hash)]
 pub struct JobId {
-    pub id: Uuid,
+    id: Uuid,
 }
 
 impl JobId {

--- a/src/job.rs
+++ b/src/job.rs
@@ -4,7 +4,7 @@ use uuid::Uuid;
 
 #[derive(Debug, PartialEq, Eq, Clone, PartialOrd, Ord, Hash)]
 pub struct JobId {
-    id: Uuid,
+    pub id: Uuid,
 }
 
 impl JobId {

--- a/src/task.rs
+++ b/src/task.rs
@@ -58,10 +58,10 @@ impl Task {
         }
     }
 
-    /// Create a new Task with a specified schedule, job function TaskId.
+    /// Create a new `Task` with a specified schedule, job function and `TaskId`.
     ///
-    /// This method is useful if you need to know T`askId`` before task scheduled,
-    /// or need to use TaskId within job context: for particular task it's TaskId is constant value,
+    /// This method is useful if you need to know `TaskId` before task scheduled,
+    /// or need to use `TaskId` within job context: for particular task it's TaskId is constant value,
     /// but JobId varies for each task run.
     ///
     /// # Examples

--- a/src/task.rs
+++ b/src/task.rs
@@ -63,27 +63,36 @@ impl Task {
     /// # Examples
     ///
     /// ```rust
-    /// use sacs::task::{CronOpts, Task, TaskSchedule};
+    /// use sacs::task::{CronOpts, Task, TaskId, TaskSchedule};
     /// use std::time::Duration;
     /// use uuid::Uuid;
     ///
     /// let schedule = TaskSchedule::Cron("*/5 * * * * *".try_into().unwrap(), CronOpts::default());
-    /// let task = Task::new_with_uuid(schedule, |id| {
+    /// let task1 = Task::new_with_id(schedule.clone(), |id| {
     ///     Box::pin(async move {
     ///         // Actual async workload here
     ///         tokio::time::sleep(Duration::from_secs(1)).await;
     ///         // ...
     ///         println!("Job {id} finished.");
     ///         })
-    ///     }, Uuid::new_v4());
+    ///     }, Uuid::new_v4().into());
+    ///
+    /// let task2 = Task::new_with_id(schedule, |id| {
+    ///     Box::pin(async move {
+    ///         // Actual async workload here
+    ///         tokio::time::sleep(Duration::from_secs(1)).await;
+    ///         // ...
+    ///         println!("Job {id} finished.");
+    ///         })
+    ///     }, TaskId::from(Uuid::new_v4()));
     /// ```
-    pub fn new_with_uuid<T>(schedule: TaskSchedule, job: T, uuid: Uuid) -> Self
-        where
-            T: 'static,
-            T: FnMut(JobId) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync,
+    pub fn new_with_id<T>(schedule: TaskSchedule, job: T, id: TaskId) -> Self
+where
+    T: 'static,
+    T: FnMut(JobId) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync,
     {
         Self {
-            id: TaskId::new_with_uuid(uuid),
+            id,
             job: Arc::new(RwLock::new(Box::new(job))),
             schedule,
             state: TaskState::default(),
@@ -126,10 +135,6 @@ impl TaskId {
     /// Constructs new unique `TaskId`.
     pub fn new() -> Self {
         Self { id: Uuid::new_v4() }
-    }
-    /// Returns the `TaskId` with the entered uuid.
-    pub fn new_with_uuid(uuid: Uuid) -> Self {
-        Self { id: uuid }
     }
 }
 impl Default for TaskId {

--- a/src/task.rs
+++ b/src/task.rs
@@ -58,7 +58,11 @@ impl Task {
         }
     }
 
-    /// Create a new Task with a specified schedule and job function with the specified uuid.
+    /// Create a new Task with a specified schedule, job function TaskId.
+    ///
+    /// This method is useful if you need to know T`askId`` before task scheduled,
+    /// or need to use TaskId within job context: for particular task it's TaskId is constant value,
+    /// but JobId varies for each task run.
     ///
     /// # Examples
     ///
@@ -68,14 +72,19 @@ impl Task {
     /// use uuid::Uuid;
     ///
     /// let schedule = TaskSchedule::Cron("*/5 * * * * *".try_into().unwrap(), CronOpts::default());
-    /// let task1 = Task::new_with_id(schedule.clone(), |id| {
+    /// let task1_id = TaskId::from(Uuid::new_v4());
+    /// let task_id = task1_id.clone();
+    ///
+    /// let task1 = Task::new_with_id(schedule.clone(), move |id| {
+    ///     let task_id = task_id.clone();
     ///     Box::pin(async move {
+    ///         println!("TaskId={task_id}.");
     ///         // Actual async workload here
     ///         tokio::time::sleep(Duration::from_secs(1)).await;
     ///         // ...
     ///         println!("Job {id} finished.");
     ///         })
-    ///     }, Uuid::new_v4().into());
+    ///     }, task1_id);
     ///
     /// let task2 = Task::new_with_id(schedule, |id| {
     ///     Box::pin(async move {
@@ -84,12 +93,12 @@ impl Task {
     ///         // ...
     ///         println!("Job {id} finished.");
     ///         })
-    ///     }, TaskId::from(Uuid::new_v4()));
+    ///     }, Uuid::new_v4().into());
     /// ```
     pub fn new_with_id<T>(schedule: TaskSchedule, job: T, id: TaskId) -> Self
-where
-    T: 'static,
-    T: FnMut(JobId) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync,
+    where
+        T: 'static,
+        T: FnMut(JobId) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync,
     {
         Self {
             id,


### PR DESCRIPTION
Hi, I think it would be useful if there was an option to also set your own task id. I've modified the code a bit as I see it for myself