### PR TITLE
feat: Make task clonnable Implement Task::with_id and Task::with_schedule methods

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1201,26 +1201,20 @@ mod test {
             .build();
 
         // Every 100ms work for 2s
-        let task_1 = Task::new_with_id(
-            TaskSchedule::Interval(Duration::from_millis(100)),
-            |_id| {
-                Box::pin(async move {
-                    tokio::time::sleep(Duration::from_secs(2)).await;
-                })
-            },
-            task_id.into(),
-        );
+        let task_1 = Task::new(TaskSchedule::Interval(Duration::from_millis(100)), |_id| {
+            Box::pin(async move {
+                tokio::time::sleep(Duration::from_secs(2)).await;
+            })
+        })
+        .with_id(task_id);
 
         // Once but with the same TaskId
-        let task_2 = Task::new_with_id(
-            TaskSchedule::Once,
-            |_id| {
-                Box::pin(async move {
-                    tokio::time::sleep(Duration::from_secs(2)).await;
-                })
-            },
-            task_id.into(),
-        );
+        let task_2 = Task::new(TaskSchedule::Once, |_id| {
+            Box::pin(async move {
+                tokio::time::sleep(Duration::from_secs(2)).await;
+            })
+        })
+        .with_id(task_id);
 
         let _id1 = scheduler.add(task_1).await.unwrap();
         let id2 = scheduler.add(task_2).await;

--- a/src/task.rs
+++ b/src/task.rs
@@ -66,7 +66,7 @@ impl Task {
     /// **_If you provide explicit [`TaskId`] value, your responsibility is to ensure uniqueness of the [`TaskId`]
     /// within instance of `Scheduler`._**
     ///
-    /// This method consumes `Task` instance and returns the same instance with specified `Id`. Since [`Task`] can be cloned
+    /// This method consumes `Task` instance and returns the same instance with specified `Id`. Since [`Task`] is cloneable
     /// this method can be used to create several identical tasks with different `TaskId`s.
     ///
     /// # Examples:
@@ -113,7 +113,7 @@ impl Task {
     ///
     /// Method is useful if you need to create new task based on existing (not scheduled yet) [`Task`].
     ///
-    /// Method consumes `Task` instance and returns the same instance with specified [`TaskSchedule`]. Since [`Task`] can be cloned
+    /// Method consumes `Task` instance and returns the same instance with specified [`TaskSchedule`]. Since [`Task`] is cloneable
     /// this method can be used to create several identical tasks with different schedules.
     ///
     /// Be careful: [`Task::clone()`] doesn't change `TaskId`, so it's your responsibility to ensure uniqueness of task's Id before


### PR DESCRIPTION
1. Make `Task` cloneable.
2. Add `Task::with_id method` and deprecate `new_with_id`
3. Add `Task::with_schedule` method