### PR TITLE
feat: Change internal ID representation from Uuid to arbitrary String

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 name = "sacs"
 readme = "README.md"
 repository = "https://github.com/alex-karpenko/sacs"
-version = "0.4.2"
+version = "0.5.0"
 exclude = [
     ".github/**",
     ".vscode/**",

--- a/src/event.rs
+++ b/src/event.rs
@@ -152,6 +152,7 @@ mod test {
         assert_eq!(EventId::from(uuid_id), event_id);
         assert_eq!(EventId::from(&uuid_id), event_id);
 
+        assert_eq!(String::from(&event_id), str_id);
         assert_eq!(String::from(event_id), str_id);
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -5,36 +5,40 @@ use uuid::Uuid;
 
 #[derive(Debug, PartialEq, Eq, Clone, PartialOrd, Ord, Hash)]
 pub(crate) struct EventId {
-    pub id: Uuid,
+    pub id: String,
 }
 
 impl Default for EventId {
     fn default() -> Self {
-        Self { id: Uuid::new_v4() }
+        Self {
+            id: Uuid::new_v4().into(),
+        }
     }
 }
 
 impl From<Uuid> for EventId {
     fn from(value: Uuid) -> Self {
-        Self { id: value }
+        Self { id: value.into() }
     }
 }
 
 impl From<&Uuid> for EventId {
     fn from(value: &Uuid) -> Self {
-        Self { id: *value }
+        Self {
+            id: value.to_string(),
+        }
     }
 }
 
-impl From<EventId> for Uuid {
+impl From<EventId> for String {
     fn from(value: EventId) -> Self {
         value.id
     }
 }
 
-impl From<&EventId> for Uuid {
+impl From<&EventId> for String {
     fn from(value: &EventId) -> Self {
-        value.id
+        value.id.to_owned()
     }
 }
 
@@ -55,14 +59,17 @@ impl std::fmt::Debug for Event {
 }
 
 impl Event {
-    pub fn new(id: EventId, time: SystemTime) -> Self {
-        Self { id, time }
+    pub fn new(id: impl Into<EventId>, time: SystemTime) -> Self {
+        Self {
+            id: id.into(),
+            time,
+        }
     }
 
     #[allow(dead_code)]
-    pub fn with_id(id: EventId) -> Self {
+    pub fn with_id(id: impl Into<EventId>) -> Self {
         Self {
-            id,
+            id: id.into(),
             time: SystemTime::now(),
         }
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -137,3 +137,21 @@ impl From<&Event> for SystemTime {
         value.time
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use uuid::Uuid;
+
+    #[test]
+    fn type_convertors() {
+        let uuid_id = Uuid::new_v4();
+        let str_id = uuid_id.to_string();
+        let event_id = EventId { id: str_id.clone() };
+
+        assert_eq!(EventId::from(uuid_id), event_id);
+        assert_eq!(EventId::from(&uuid_id), event_id);
+
+        assert_eq!(String::from(event_id), str_id);
+    }
+}

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -205,7 +205,7 @@ mod test {
             })
         });
         let job_0 = task_0.job.clone();
-        let job_id_0 = JobId::new();
+        let job_id_0 = JobId::new("task 0 id");
         let job_0 = Job::new(job_id_0.clone(), job_0);
 
         let task_1 = Task::new(TaskSchedule::Once, |_id| {
@@ -214,7 +214,7 @@ mod test {
             })
         });
         let job_1 = task_1.job.clone();
-        let job_id_1 = JobId::new();
+        let job_id_1 = JobId::new("task 1 id");
         let job_1 = Job::new(job_id_1.clone(), job_1);
 
         executor.enqueue(job_0).await.unwrap();

--- a/src/job.rs
+++ b/src/job.rs
@@ -131,4 +131,18 @@ mod test {
         assert!(JobState::Completed.finished());
         assert!(JobState::Cancelled.finished());
     }
+
+    #[test]
+    fn type_convertors() {
+        let task_id = TaskId::from("TASK_ID");
+        let job_id = JobId::from(task_id.clone());
+
+        assert_eq!(JobId::from(task_id.clone()).task_id, task_id);
+        assert_eq!(JobId::from(&task_id).task_id, task_id);
+
+        assert_eq!(
+            format!("{job_id}"),
+            format!("{}/{}", task_id.to_string(), job_id.job_id.to_string())
+        );
+    }
 }

--- a/src/job.rs
+++ b/src/job.rs
@@ -142,11 +142,8 @@ mod test {
 
         assert_eq!(
             format!("{job_id}"),
-            format!("{}/{}", task_id.to_string(), job_id.job_id.to_string())
+            format!("{}/{}", task_id, job_id.job_id)
         );
-        assert_eq!(
-            job_id.to_string(),
-            format!("{}/{}", task_id.to_string(), job_id.job_id.to_string())
-        );
+        assert_eq!(job_id.to_string(), format!("{}/{}", task_id, job_id.job_id));
     }
 }

--- a/src/job.rs
+++ b/src/job.rs
@@ -144,5 +144,9 @@ mod test {
             format!("{job_id}"),
             format!("{}/{}", task_id.to_string(), job_id.job_id.to_string())
         );
+        assert_eq!(
+            job_id.to_string(),
+            format!("{}/{}", task_id.to_string(), job_id.job_id.to_string())
+        );
     }
 }

--- a/src/job.rs
+++ b/src/job.rs
@@ -142,8 +142,11 @@ mod test {
 
         assert_eq!(
             format!("{job_id}"),
-            format!("{}/{}", task_id, job_id.job_id)
+            format!("{}/{}", job_id.task_id, job_id.job_id)
         );
-        assert_eq!(job_id.to_string(), format!("{}/{}", task_id, job_id.job_id));
+        assert_eq!(
+            String::from(job_id.clone()),
+            format!("{}/{}", job_id.task_id, job_id.job_id)
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@
 
 mod event;
 mod executor;
-mod job;
+pub mod job;
 mod queue;
 pub mod scheduler;
 pub mod task;

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1194,7 +1194,7 @@ mod test {
     #[tokio::test]
     async fn reject_duplicated_task() {
         let scheduler = SchedulerBuilder::new()
-            .garbage_collector(GarbageCollector::immediate())
+            .garbage_collector(GarbageCollector::disabled())
             .build();
 
         // Every 100ms work for 2s

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1217,7 +1217,7 @@ mod test {
         let err = id2.err().unwrap();
         match err {
             Error::DuplicatedTaskId(id) => {
-                assert_eq!(id, TaskId::from(task_id))
+                assert_eq!(id, TaskId::from("TASK_ID"))
             }
             _ => unreachable!("Incorrect error type or TaskId"),
         }

--- a/src/task.rs
+++ b/src/task.rs
@@ -756,8 +756,15 @@ mod test {
         let uuid_id = Uuid::new_v4();
         let str_id = uuid_id.to_string();
 
-        assert_eq!(TaskId::from(String::from("TASK_ID")).id, String::from("TASK_ID"));
-        assert_eq!(TaskId::from(&String::from("TASK_ID")).id, String::from("TASK_ID"));
+        assert_eq!(
+            TaskId::from(String::from("TASK_ID")).id,
+            String::from("TASK_ID")
+        );
+        assert_eq!(
+            TaskId::from(&String::from("TASK_ID")).id,
+            String::from("TASK_ID")
+        );
+
         assert_eq!(TaskId::from("TASK_ID").id, String::from("TASK_ID"));
 
         assert_eq!(TaskId::from(uuid_id).id, str_id);

--- a/src/task.rs
+++ b/src/task.rs
@@ -750,4 +750,20 @@ mod test {
             }
         );
     }
+
+    #[test]
+    fn type_convertors() {
+        let uuid_id = Uuid::new_v4();
+        let str_id = uuid_id.to_string();
+
+        assert_eq!(TaskId::from(String::from("TASK_ID")).id, String::from("TASK_ID"));
+        assert_eq!(TaskId::from(&String::from("TASK_ID")).id, String::from("TASK_ID"));
+        assert_eq!(TaskId::from("TASK_ID").id, String::from("TASK_ID"));
+
+        assert_eq!(TaskId::from(uuid_id).id, str_id);
+        assert_eq!(TaskId::from(&uuid_id).id, str_id);
+
+        assert_eq!(String::from(TaskId::from(uuid_id)), str_id);
+        assert_eq!(String::from(&TaskId::from(uuid_id)), str_id);
+    }
 }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -8,6 +8,7 @@ use futures::future::select_all;
 use std::collections::HashMap;
 use tokio::{join, select, sync::mpsc::Sender, task::JoinHandle};
 use tracing::{debug, warn};
+use uuid::Uuid;
 
 const WORKER_CONTROL_CHANNEL_SIZE: usize = 1024;
 
@@ -94,7 +95,7 @@ impl Worker {
         let mut handlers: Vec<JoinHandle<()>> = Vec::new();
 
         // Push single always-pending job to avoid panics on empty select_all
-        let fake_id = JobId::new();
+        let fake_id = JobId::new(Uuid::new_v4());
         let fake_handler =
             tokio::task::spawn(Box::pin(async { futures::future::pending::<()>().await }));
         ids.push(fake_id);

--- a/tests/generic.rs
+++ b/tests/generic.rs
@@ -1,4 +1,5 @@
 use sacs::{
+    job::JobId,
     scheduler::{
         GarbageCollector, RuntimeThreads, Scheduler, ShutdownOpts, TaskScheduler,
         WorkerParallelism, WorkerType,
@@ -8,7 +9,6 @@ use sacs::{
 };
 use std::{sync::Arc, time::Duration};
 use tokio::sync::RwLock;
-use uuid::Uuid;
 
 async fn basic_test_suite(
     scheduler: Scheduler,
@@ -23,7 +23,7 @@ async fn basic_test_suite(
     );
 
     let logs = Arc::new(RwLock::new(Vec::<String>::new()));
-    let jobs = Arc::new(RwLock::new(Vec::<Uuid>::new()));
+    let jobs = Arc::new(RwLock::new(Vec::<JobId>::new()));
 
     for s in 0..schedules.len() {
         let log = logs.clone();
@@ -33,7 +33,7 @@ async fn basic_test_suite(
             let log = log.clone();
             let jobs = jobs.clone();
             Box::pin(async move {
-                jobs.write().await.push(id.clone().into());
+                jobs.write().await.push(id.clone());
                 log.write().await.push(format!("{},start,{id}", s));
                 tokio::time::sleep(task_duration).await;
                 log.write().await.push(format!("{},finish,{id}", s));


### PR DESCRIPTION
1. Change internal representation of `TaskId` from `Uuid` to arbitrary `String`
2. Expose `JobId` and extend it to contain `TaskId` as well
3. Change interface of `TaskId` constructor to consume any type convertable to `String`