### PR TITLE
fix: Fix private type exposition error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 name = "sacs"
 readme = "README.md"
 repository = "https://github.com/alex-karpenko/sacs"
-version = "0.9.2"
+version = "0.9.3"
 exclude = [".github/**", ".vscode/**", "TODO.md", "Cargo.lock", "target/**", ".gitignore", "mutants.*/**"]
 
 [dependencies]

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -20,7 +20,7 @@ const QUEUE_CONTROL_CHANNEL_SIZE: usize = 1024;
 const EMPTY_QUEUE_SLEEP_DURATION_SECONDS: u64 = 3600;
 
 /// Events queue behavior
-pub trait EventTimeQueue: Debug {
+pub(crate) trait EventTimeQueue: Debug {
     /// Blocks execution until next event time.
     /// Returns Result with event and remove it from queue.
     async fn next(&self) -> Result<Event>;


### PR DESCRIPTION
Fix compilation error about potential exposition of the private type to public API.
Actually, whole module `queue` isn't public, so that trait isn't exposed at all.

```
error[E0446]: crate-private type `event::Event` in public interface
  --> src/queue.rs:26:29
   |
26 |     async fn next(&self) -> Result<Event>;
   |                             ^^^^^^^^^^^^^ can't leak crate-private type
   |
  ::: src/event.rs:69:1
   |
69 | pub(crate) struct Event {
   | ----------------------- `event::Event` declared as crate-private

error[E0446]: crate-private type `event::Event` in public interface
  --> src/queue.rs:30:52
   |
30 |     async fn try_next(&self, timeout: Duration) -> Option<Result<Event>> {
   |                                                    ^^^^^^^^^^^^^^^^^^^^^ can't leak crate-private type
   |
  ::: src/event.rs:69:1
   |
69 | pub(crate) struct Event {
   | ----------------------- `event::Event` declared as crate-private

For more information about this error, try `rustc --explain E0446`.
```